### PR TITLE
FEATURE: ANT CASTES & EVOLUTION LAB EXPANSION

### DIFF
--- a/src/render2d/canvasRenderer.ts
+++ b/src/render2d/canvasRenderer.ts
@@ -1,5 +1,5 @@
 import { CELL_SIZE, WORLD_WIDTH, WORLD_HEIGHT } from '../shared/constants';
-import { AntState, TileType, type SimState, type SimSnapshot } from '../sim/core/types';
+import { AntState, AntType, TileType, type SimState, type SimSnapshot } from '../sim/core/types';
 
 export interface RenderOptions {
     showPheromones: boolean;
@@ -99,13 +99,25 @@ export function renderSimulation(ctx: CanvasRenderingContext2D, state: SimState 
         ctx.translate((ant.x + 0.5) * CELL_SIZE, (ant.y + 0.5) * CELL_SIZE);
         ctx.rotate(ant.angle);
 
-        // Color based on searching logic
+        let scale = 1;
+        if (ant.type === AntType.SOLDIER) {
+            scale = 1.5; // Soldiers are larger
+        } else if (ant.type === AntType.SCOUT) {
+            scale = 0.8; // Scouts are slightly smaller
+        }
+        ctx.scale(scale, scale);
+
+        // Color based on searching logic and type
         if (ant.hasFood) {
             ctx.fillStyle = '#ffaa00'; // Yellowish for food carrier
+        } else if (ant.type === AntType.SOLDIER) {
+            ctx.fillStyle = '#ff5555'; // Reddish for soldier
+        } else if (ant.type === AntType.SCOUT) {
+            ctx.fillStyle = '#55aaff'; // Light blue for scout
         } else if (ant.state === AntState.SEARCHING) {
             ctx.fillStyle = '#ffffff'; // White default
         } else {
-            ctx.fillStyle = '#bbffbb'; // Soft green if returning but no food? (fallback)
+            ctx.fillStyle = '#bbffbb'; // Soft green if returning
         }
 
         // Simple shape

--- a/src/sim/core/ants.ts
+++ b/src/sim/core/ants.ts
@@ -1,11 +1,12 @@
 import { TOTAL_ANTS } from '../../shared/constants';
-import { AntState, type Ant } from './types';
+import { AntState, AntType, type Ant } from './types';
 
 export function createAnts(nestX: number, nestY: number): Ant[] {
     const ants: Ant[] = [];
     for (let i = 0; i < TOTAL_ANTS; i++) {
         ants.push({
             id: i,
+            type: AntType.WORKER,
             x: nestX,
             y: nestY,
             angle: Math.random() * Math.PI * 2,

--- a/src/sim/core/tick.ts
+++ b/src/sim/core/tick.ts
@@ -48,6 +48,7 @@ export function tick(state: SimState, scratchBuffer: Float32Array) {
                 const newAntId = state.ants.length > 0 ? state.ants[state.ants.length - 1].id + 1 : 0;
                 state.ants.push({
                     id: newAntId,
+                    type: item.antType,
                     x: state.nestX,
                     y: state.nestY,
                     angle: Math.random() * Math.PI * 2,
@@ -74,6 +75,7 @@ export function tick(state: SimState, scratchBuffer: Float32Array) {
         state.brood.push({
             id: nextId,
             type: BroodType.EGG,
+            antType: state.productionType,
             progress: 0,
             x: bx,
             y: by

--- a/src/sim/core/types.ts
+++ b/src/sim/core/types.ts
@@ -19,9 +19,17 @@ export const BroodType = {
 } as const;
 export type BroodType = typeof BroodType[keyof typeof BroodType];
 
+export const AntType = {
+    WORKER: 0,
+    SCOUT: 1,
+    SOLDIER: 2
+} as const;
+export type AntType = typeof AntType[keyof typeof AntType];
+
 export interface BroodItem {
     id: number;
     type: BroodType;
+    antType: AntType; // The caste this brood will hatch into
     progress: number; // 0 to 1
     x: number;
     y: number;
@@ -29,6 +37,7 @@ export interface BroodItem {
 
 export interface Ant {
     id: number;
+    type: AntType;
     x: number;
     y: number;
     angle: number;       // heading in radians
@@ -43,6 +52,8 @@ export interface SimUpgrades {
     antSpeedLevel: number;
     sensorRangeLevel: number;
     pheromoneDropLevel: number;
+    scoutSpeedLevel: number; // Scout specific
+    soldierStrengthLevel: number; // Soldier specific
 }
 
 export interface SimState {
@@ -58,6 +69,7 @@ export interface SimState {
     nestX: number;
     nestY: number;
     upgrades: SimUpgrades;
+    productionType: AntType;
 }
 
 export interface SimSnapshot {
@@ -70,4 +82,5 @@ export interface SimSnapshot {
     foodTileCount: number;
     colonyFood: number;
     upgrades: SimUpgrades;
+    productionType: AntType;
 }

--- a/src/sim/core/upgrades.ts
+++ b/src/sim/core/upgrades.ts
@@ -38,13 +38,33 @@ export const UPGRADE_DEFS: Record<keyof SimUpgrades, UpgradeDef> = {
         costMultiplier: 1.8,
         maxLevel: 5,
         getValue: (lvl) => 0.1 + (lvl * 0.05) // Base: 0.1, Max: 0.35
+    },
+    scoutSpeedLevel: {
+        id: 'scoutSpeedLevel',
+        name: 'Scout Agility',
+        description: 'Increases scout movement speed and sensor efficiency.',
+        baseCost: 30,
+        costMultiplier: 1.7,
+        maxLevel: 5,
+        getValue: (lvl) => 1.0 + (lvl * 0.2) // Multiplier for scout base
+    },
+    soldierStrengthLevel: {
+        id: 'soldierStrengthLevel',
+        name: 'Soldier Strength',
+        description: 'Increases soldier defense against future threats.',
+        baseCost: 50,
+        costMultiplier: 2.0,
+        maxLevel: 5,
+        getValue: (lvl) => 1.0 + (lvl * 0.5) // Base: 1.0, Max: 3.5
     }
 };
 
 export const INITIAL_UPGRADES: SimUpgrades = {
     antSpeedLevel: 0,
     sensorRangeLevel: 0,
-    pheromoneDropLevel: 0
+    pheromoneDropLevel: 0,
+    scoutSpeedLevel: 0,
+    soldierStrengthLevel: 0
 };
 
 export function getUpgradeCost(def: UpgradeDef, currentLevel: number): number {

--- a/src/sim/systems/antSystem.test.ts
+++ b/src/sim/systems/antSystem.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import { updateAnts } from './antSystem';
-import { AntState, TileType, type SimState } from '../core/types';
+import { AntState, AntType, TileType, type SimState } from '../core/types';
 import { WORLD_WIDTH, WORLD_HEIGHT } from '../../shared/constants';
 import { INITIAL_UPGRADES } from '../core/upgrades';
 import { getIndex } from '../utils/grid';
@@ -25,7 +25,8 @@ describe('Ant System', () => {
             colonyFood: 0,
             nestX: 10,
             nestY: 10,
-            upgrades: { ...INITIAL_UPGRADES }
+            upgrades: { ...INITIAL_UPGRADES },
+            productionType: AntType.WORKER
         };
     });
 
@@ -42,6 +43,7 @@ describe('Ant System', () => {
         
         state.ants.push({
             id: 1,
+            type: AntType.WORKER,
             x: foodX,
             y: foodY,
             angle: 0,
@@ -67,6 +69,7 @@ describe('Ant System', () => {
 
         state.ants.push({
             id: 1,
+            type: AntType.WORKER,
             x: foodX,
             y: foodY,
             angle: 0,
@@ -88,6 +91,7 @@ describe('Ant System', () => {
         
         state.ants.push({
             id: 1,
+            type: AntType.WORKER,
             x: nestX,
             y: nestY,
             angle: 0,
@@ -116,6 +120,7 @@ describe('Ant System', () => {
         const initialAngle = 0;
         state.ants.push({
             id: 1,
+            type: AntType.WORKER,
             x: antX,
             y: antY,
             angle: initialAngle,

--- a/src/ui/panels/ControlsPanel.tsx
+++ b/src/ui/panels/ControlsPanel.tsx
@@ -1,6 +1,6 @@
 import { useUIStore } from '../store/uiStore';
 import { simWorker } from '../../worker/simBridge';
-import { BroodType } from '../../sim/core/types';
+import { BroodType, AntType } from '../../sim/core/types';
 import './ControlsPanel.css';
 
 export const ControlsPanel = () => {
@@ -36,6 +36,12 @@ export const ControlsPanel = () => {
         setSpeedMultiplier(newSpeed);
     };
 
+    const handleProductionType = async (type: AntType) => {
+        await simWorker.setProductionType(type);
+    };
+
+    const currentProductionType = simState?.productionType ?? AntType.WORKER;
+
     return (
         <div className="controls-panel">
             <h2 className="panel-title">Colony Controls</h2>
@@ -52,6 +58,30 @@ export const ControlsPanel = () => {
                 <div className="status-item">
                     <span className="label">Colony Food</span>
                     <span className="value text-highlight">{Math.floor(simState?.colonyFood || 0)}</span>
+                </div>
+            </div>
+
+            <div className="control-section">
+                <h3 className="section-title">Spawn Selection</h3>
+                <div className="button-group">
+                    <button
+                        className={`btn-toggle ${currentProductionType === AntType.WORKER ? 'active' : ''}`}
+                        onClick={() => handleProductionType(AntType.WORKER)}
+                    >
+                        Worker
+                    </button>
+                    <button
+                        className={`btn-toggle ${currentProductionType === AntType.SCOUT ? 'active' : ''}`}
+                        onClick={() => handleProductionType(AntType.SCOUT)}
+                    >
+                        Scout
+                    </button>
+                    <button
+                        className={`btn-toggle ${currentProductionType === AntType.SOLDIER ? 'active' : ''}`}
+                        onClick={() => handleProductionType(AntType.SOLDIER)}
+                    >
+                        Soldier
+                    </button>
                 </div>
             </div>
 

--- a/src/worker/simWorker.ts
+++ b/src/worker/simWorker.ts
@@ -4,7 +4,7 @@ import { createAnts } from '../sim/core/ants';
 import { createPheromones } from '../sim/core/pheromones';
 import { tick } from '../sim/core/tick';
 import { TICK_INTERVAL_MS } from '../shared/constants';
-import type { SimState, SimUpgrades, SimSnapshot } from '../sim/core/types';
+import { AntType, type SimState, type SimUpgrades, type SimSnapshot } from '../sim/core/types';
 import { UPGRADE_DEFS, getUpgradeCost, INITIAL_UPGRADES } from '../sim/core/upgrades';
 
 let state: SimState | null = null;
@@ -29,7 +29,8 @@ const api = {
             colonyFood: 100, // Start with some food for buying upgrades faster
             nestX,
             nestY,
-            upgrades: { ...INITIAL_UPGRADES }
+            upgrades: { ...INITIAL_UPGRADES },
+            productionType: AntType.WORKER
         };
     },
     start() {
@@ -59,6 +60,9 @@ const api = {
     setSpeed(speed: number) {
         currentSpeed = speed;
     },
+    setProductionType(type: AntType) {
+        if (state) state.productionType = type;
+    },
     purchaseUpgrade(upgradeId: keyof SimUpgrades) {
         if (!state) return;
         const def = UPGRADE_DEFS[upgradeId];
@@ -86,7 +90,8 @@ const api = {
             grid: state.grid,
             foodTileCount: state.foodTileCount,
             colonyFood: state.colonyFood,
-            upgrades: state.upgrades
+            upgrades: state.upgrades,
+            productionType: state.productionType
         };
     }
 };


### PR DESCRIPTION
Closes #4

Introduce specialization to the colony by adding different ant castes and expanding the upgrade tree.

*   **Add 'Scout' caste:** Faster, longer sensor range, carries no food.
*   **Add 'Soldier' caste:** Larger, slower, can defend against future threats.
*   **Expand with caste-specific bonuses:** Added 'Scout Agility' and 'Soldier Strength'.
*   **Update UI:** Allow choosing which caste to spawn or upgrade.
*   **Visual differentiation:** 2D and 3D renderers now scale and tint ants based on their caste.