### PR TITLE
fix: add bounds checking to getIndex function

### DIFF
--- a/src/sim/utils/grid.test.ts
+++ b/src/sim/utils/grid.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { getIndex, inBounds } from './grid';
+
+describe('Grid Utilities', () => {
+    describe('inBounds', () => {
+        it('should return true for valid coordinates', () => {
+            expect(inBounds(0, 0)).toBe(true);
+            expect(inBounds(64, 64)).toBe(true);
+            expect(inBounds(127, 127)).toBe(true);
+        });
+
+        it('should return false for out of bounds coordinates', () => {
+            expect(inBounds(-1, 0)).toBe(false);
+            expect(inBounds(0, -1)).toBe(false);
+            expect(inBounds(128, 0)).toBe(false);
+            expect(inBounds(0, 128)).toBe(false);
+            expect(inBounds(200, 200)).toBe(false);
+        });
+    });
+
+    describe('getIndex', () => {
+        it('should return correct index for valid coordinates', () => {
+            expect(getIndex(0, 0)).toBe(0);
+            expect(getIndex(1, 0)).toBe(1);
+            expect(getIndex(0, 1)).toBe(128);
+            expect(getIndex(127, 127)).toBe(128 * 127 + 127);
+        });
+
+        it('should handle fractional coordinates correctly', () => {
+            expect(getIndex(10.3, 20.7)).toBe(getIndex(10, 20));
+            expect(getIndex(10.9, 20.1)).toBe(getIndex(10, 20));
+        });
+
+        it('should throw error for negative coordinates', () => {
+            expect(() => getIndex(-1, 0)).toThrow('out of bounds');
+            expect(() => getIndex(0, -1)).toThrow('out of bounds');
+            expect(() => getIndex(-10, -20)).toThrow('out of bounds');
+        });
+
+        it('should throw error for coordinates beyond world bounds', () => {
+            expect(() => getIndex(128, 0)).toThrow('out of bounds');
+            expect(() => getIndex(0, 128)).toThrow('out of bounds');
+            expect(() => getIndex(200, 200)).toThrow('out of bounds');
+        });
+
+        it('should throw error with descriptive message', () => {
+            try {
+                getIndex(-5, 10);
+                throw new Error('Should have thrown an error');
+            } catch (error: unknown) {
+                expect(error).toBeInstanceOf(Error);
+                expect((error as Error).message).toContain('(-5, 10)');
+                expect((error as Error).message).toContain('out of bounds');
+            }
+        });
+    });
+});

--- a/src/sim/utils/grid.ts
+++ b/src/sim/utils/grid.ts
@@ -1,11 +1,33 @@
 import { WORLD_WIDTH, WORLD_HEIGHT } from '../../shared/constants';
 
-// Get 1D index from 2D coordinates
+/**
+ * Get 1D index from 2D coordinates with bounds checking
+ * 
+ * @param x - X coordinate (0 to WORLD_WIDTH-1)
+ * @param y - Y coordinate (0 to WORLD_HEIGHT-1)
+ * @returns 1D index for array access
+ * @throws {Error} If coordinates are out of bounds
+ */
 export function getIndex(x: number, y: number): number {
-    return Math.floor(y) * WORLD_WIDTH + Math.floor(x);
+    const floorX = Math.floor(x);
+    const floorY = Math.floor(y);
+    
+    // Validate bounds to prevent array out-of-bounds access
+    if (!inBounds(floorX, floorY)) {
+        throw new Error(`Coordinates (${floorX}, ${floorY}) are out of bounds. ` +
+                      `Valid range: x=[0,${WORLD_WIDTH-1}], y=[0,${WORLD_HEIGHT-1}]`);
+    }
+    
+    return floorY * WORLD_WIDTH + floorX;
 }
 
-// Check if x, y is within bounds
+/**
+ * Check if x, y coordinates are within the world bounds
+ * 
+ * @param x - X coordinate to check
+ * @param y - Y coordinate to check
+ * @returns true if coordinates are within bounds, false otherwise
+ */
 export function inBounds(x: number, y: number): boolean {
     return x >= 0 && x < WORLD_WIDTH && y >= 0 && y < WORLD_HEIGHT;
 }


### PR DESCRIPTION
## Description

This PR fixes issue #11 by adding bounds checking to the getIndex function to prevent array out-of-bounds access.

## Changes Made

- Added bounds validation: The getIndex() function now validates that coordinates are within the world bounds before calculating the index
- Improved documentation: Added comprehensive JSDoc comments for both getIndex() and inBounds() functions
- Added unit tests: Created grid.test.ts with 7 tests covering valid coordinates, fractional coordinates, negative coordinate error cases, out-of-bounds coordinate error cases, and descriptive error messages

## Technical Details

The fix ensures that:
1. Coordinates are floored to integers (as before)
2. Floored coordinates are validated against world bounds
3. A descriptive error is thrown if coordinates are out of bounds
4. The error message includes the invalid coordinates and valid range

## Testing

- All existing tests continue to pass
- New tests verify the bounds checking behavior
- Build completes successfully
- No breaking changes to existing functionality

## Related Issues

Fixes #11