### PR TITLE
Optimize initial bundle size

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,15 @@
-import { useEffect, useRef, useState } from 'react';
+import { lazy, Suspense, useEffect, useRef, useState } from 'react';
 import { simWorker } from './worker/simBridge';
 import { useUIStore } from './ui/store/uiStore';
 import { renderSimulation, invalidateStaticCanvas } from './render2d/canvasRenderer';
 import { ControlsPanel } from './ui/panels/ControlsPanel';
 import { UpgradesPanel } from './ui/panels/UpgradesPanel';
-import { AntScene } from './render3d/AntScene';
 import { WORLD_WIDTH, WORLD_HEIGHT, CELL_SIZE } from './shared/constants';
 import './index.css';
+
+const LazyAntScene = lazy(() =>
+  import('./render3d/AntScene').then((module) => ({ default: module.AntScene }))
+);
 
 function App() {
   const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -72,7 +75,7 @@ function App() {
     <div className="app-container" role="main" aria-label="Ant colony simulation">
       {isLoading ? (
         <div className="loading-overlay" role="alert" aria-live="polite">
-          <div className="loading-spinner" role="progressbar" aria-busy="true"></div>
+          <div className="loading-spinner" aria-hidden="true"></div>
           <p>Initializing Ant Colony...</p>
         </div>
       ) : (
@@ -89,7 +92,16 @@ function App() {
                 tabIndex={0}
               />
             ) : (
-              <AntScene />
+              <Suspense
+                fallback={
+                  <div className="loading-overlay" role="status" aria-live="polite" aria-label="Loading 3D view">
+                    <div className="loading-spinner" aria-hidden="true"></div>
+                    <p>Loading 3D view...</p>
+                  </div>
+                }
+              >
+                <LazyAntScene />
+              </Suspense>
             )}
           </div>
           <div className="panels-container">


### PR DESCRIPTION
## Summary\n- Lazy-load the 3D scene so the main app bundle no longer includes the React Three Fiber / Three.js stack.\n- Add a loading fallback for the first 3D render and clean up spinner accessibility.\n\n## Verification\n- 
> temp-vite@0.0.0 build
> tsc -b && vite build

vite v7.3.1 building client environment for production...
transforming...
✓ 604 modules transformed.
rendering chunks...
computing gzip size...
dist/index.html                      0.46 kB │ gzip:   0.29 kB
dist/assets/simWorker-B4Gsn-8E.js   12.09 kB
dist/assets/index-2AoqwbzO.css       5.18 kB │ gzip:   1.68 kB
dist/assets/index-DDAuo9QE.js      209.54 kB │ gzip:  66.28 kB
dist/assets/AntScene-Cw8GDKlX.js   958.29 kB │ gzip: 261.64 kB
✓ built in 1.70s\n- 
> temp-vite@0.0.0 lint
> eslint .\n- 
> temp-vite@0.0.0 test
> vitest run


[1m[46m RUN [49m[22m [36mv4.0.18 [39m[90m/Users/openclaw/Github/antcolony-sim[39m

 [32m✓[39m src/sim/utils/grid.test.ts [2m([22m[2m7 tests[22m[2m)[22m[32m 2[2mms[22m[39m
 [32m✓[39m src/sim/core/pheromones.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 7[2mms[22m[39m
 [32m✓[39m src/sim/systems/antSystem.test.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 3[2mms[22m[39m
 [32m✓[39m src/render3d/Ants3D.test.tsx [2m([22m[2m1 test[22m[2m)[22m[32m 1[2mms[22m[39m

[2m Test Files [22m [1m[32m4 passed[39m[22m[90m (4)[39m
[2m      Tests [22m [1m[32m18 passed[39m[22m[90m (18)[39m
[2m   Start at [22m 22:51:05
[2m   Duration [22m 190ms[2m (transform 140ms, setup 0ms, import 219ms, tests 13ms, environment 0ms)[22m\n\nFixes #18