### PR TITLE
Refactor: Extract coordinate transformation logic

### DIFF
--- a/src/render3d/Ants3D.tsx
+++ b/src/render3d/Ants3D.tsx
@@ -2,7 +2,8 @@ import React, { useRef, useMemo } from 'react';
 import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
 import { useUIStore } from '../ui/store/uiStore';
-import { WORLD_WIDTH, WORLD_HEIGHT, CELL_SIZE } from '../shared/constants';
+
+import { getWorldPosition } from './utils';
 import { AntType } from '../sim/core/types';
 
 const dummy = new THREE.Object3D();
@@ -63,8 +64,7 @@ export const Ants3D: React.FC = () => {
         for (let i = 0; i < count; i++) {
             const ant = simState.ants[i];
 
-            const baseX = (ant.x - WORLD_WIDTH / 2) * CELL_SIZE;
-            const baseZ = (ant.y - WORLD_HEIGHT / 2) * CELL_SIZE;
+            const [baseX, baseZ] = getWorldPosition(ant.x, ant.y);
 
             // Wobble animation
             // Use ant id to desynchronize the wobble

--- a/src/render3d/Brood3D.tsx
+++ b/src/render3d/Brood3D.tsx
@@ -2,7 +2,8 @@ import React, { useRef } from 'react';
 import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
 import { useUIStore } from '../ui/store/uiStore';
-import { WORLD_WIDTH, WORLD_HEIGHT, CELL_SIZE } from '../shared/constants';
+
+import { getWorldPosition } from './utils';
 import { BroodType } from '../sim/core/types';
 
 const dummy = new THREE.Object3D();
@@ -24,8 +25,7 @@ export const Brood3D: React.FC = () => {
 
         for (let i = 0; i < count; i++) {
             const item = state.brood[i];
-            const x = (item.x - WORLD_WIDTH / 2) * CELL_SIZE;
-            const z = (item.y - WORLD_HEIGHT / 2) * CELL_SIZE;
+            const [x, z] = getWorldPosition(item.x, item.y);
 
             dummy.position.set(x, 0.2, z);
             

--- a/src/render3d/Terrain3D.tsx
+++ b/src/render3d/Terrain3D.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import * as THREE from 'three';
 import { useUIStore } from '../ui/store/uiStore';
 import { WORLD_WIDTH, WORLD_HEIGHT, CELL_SIZE } from '../shared/constants';
+import { getWorldPosition } from './utils';
 import { TileType, type SimState, type SimSnapshot } from '../sim/core/types';
 
 export const Terrain3D: React.FC = () => {
@@ -21,8 +22,7 @@ export const Terrain3D: React.FC = () => {
             if (st.grid[i] !== TileType.FOOD) continue;
             const gx = i % WORLD_WIDTH;
             const gy = Math.floor(i / WORLD_WIDTH);
-            const x = (gx - WORLD_WIDTH / 2) * CELL_SIZE;
-            const z = (gy - WORLD_HEIGHT / 2) * CELL_SIZE;
+            const [x, z] = getWorldPosition(gx, gy);
             dummy.position.set(x, (CELL_SIZE * 0.6) / 2, z);
             dummy.scale.set(CELL_SIZE * 0.8, CELL_SIZE * 0.6, CELL_SIZE * 0.8);
             dummy.updateMatrix();
@@ -48,8 +48,7 @@ export const Terrain3D: React.FC = () => {
                 const gx = i % WORLD_WIDTH;
                 const gy = Math.floor(i / WORLD_WIDTH);
 
-                const x = (gx - WORLD_WIDTH / 2) * CELL_SIZE;
-                const z = (gy - WORLD_HEIGHT / 2) * CELL_SIZE;
+                const [x, z] = getWorldPosition(gx, gy);
 
                 dummy.position.set(x, yOffset, z);
 

--- a/src/render3d/utils.ts
+++ b/src/render3d/utils.ts
@@ -1,0 +1,13 @@
+import { WORLD_WIDTH, WORLD_HEIGHT, CELL_SIZE } from '../shared/constants';
+
+/**
+ * Converts 2D grid coordinates to 3D world coordinates.
+ * @param gridX The X coordinate on the grid
+ * @param gridY The Y coordinate on the grid
+ * @returns A tuple [worldX, worldZ]
+ */
+export function getWorldPosition(gridX: number, gridY: number): [number, number] {
+    const worldX = (gridX - WORLD_WIDTH / 2) * CELL_SIZE;
+    const worldZ = (gridY - WORLD_HEIGHT / 2) * CELL_SIZE;
+    return [worldX, worldZ];
+}


### PR DESCRIPTION
Extracted coordinate transformation duplicate logic from `Ants3D.tsx`, `Terrain3D.tsx`, and `Brood3D.tsx` into a helper function `getWorldPosition` inside `src/render3d/utils.ts`.

This resolves the issue of duplicate code in the 3D rendering cluster.

---
*PR created automatically by Jules for task [17265711804405625818](https://jules.google.com/task/17265711804405625818) started by @deadronos*